### PR TITLE
Fixed comment on decodeProof

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Additionally, the library provides some auxiliary `pure` functions to facilitate
 - **decodeProof**:
   - _Description_: Decode from bytes to VRF proof
   - _Input_:
-    - *_proof*: The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`
+    - *_proof*: The VRF proof as bytes
   - _Output_:
     - The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`
 - **decodePoint**:

--- a/contracts/VRF.sol
+++ b/contracts/VRF.sol
@@ -188,7 +188,7 @@ library VRF {
   }
 
   /// @dev Decode VRF proof from bytes
-  /// @param _proof The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`
+  /// @param _proof The VRF proof as bytes
   /// @return The VRF proof as an array composed of `[gamma-x, gamma-y, c, s]`
   function decodeProof(bytes memory _proof) internal pure returns (uint[4] memory) {
     require(_proof.length == 81, "Malformed VRF proof");


### PR DESCRIPTION
In the specified comment, it's mentioned that the argument received is an array composed of `[gamma-x, gamma-y, c, s]` but instead, the argument received is `bytes`